### PR TITLE
Refactor: use common RestClient to make rest calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+.idea/
+

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <repository.name>hygieia-relateditems-collector</repository.name>
         <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
         <bc.version>3.0.1</bc.version>
-        <com.capitalone.dashboard.core.version>3.1.6-SNAPSHOT</com.capitalone.dashboard.core.version>
+        <com.capitalone.dashboard.core.version>3.1.9</com.capitalone.dashboard.core.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>3.8.1</commons.lang.version>
         <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
@@ -743,4 +743,4 @@
     </profiles>
 
 </project>
-© 2019 Git
+

--- a/src/main/java/com/capitalone/dashboard/client/DefaultRelatedItemsClient.java
+++ b/src/main/java/com/capitalone/dashboard/client/DefaultRelatedItemsClient.java
@@ -1,5 +1,6 @@
 package com.capitalone.dashboard.client;
 
+import com.capitalone.dashboard.client.RestClient;
 import com.capitalone.dashboard.collector.RelatedItemSettings;
 import com.capitalone.dashboard.misc.HygieiaException;
 import com.capitalone.dashboard.model.AutoDiscoverCollectorItem;
@@ -59,7 +60,7 @@ import java.util.stream.Collectors;
 @Component
 public class DefaultRelatedItemsClient implements RelatedItemsClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRelatedItemsClient.class);
-    private final RestOperations restOperations;
+    private final RestClient restClient;
     private RelatedItemSettings relatedItemSettings;
     private String bearerToken;
     private RelatedCollectorItemRepository relatedCollectorItemRepository;
@@ -73,7 +74,7 @@ public class DefaultRelatedItemsClient implements RelatedItemsClient {
 
 
     @Autowired
-    public DefaultRelatedItemsClient(RelatedItemSettings relatedItemSettings, Supplier<RestOperations> restOperationsSupplier,
+    public DefaultRelatedItemsClient(RelatedItemSettings relatedItemSettings, RestClient restClient,
                                      RelatedCollectorItemRepository relatedCollectorItemRepository,
                                      DashboardRepository dashboardRepository,
                                      ComponentRepository componentRepository,
@@ -81,7 +82,7 @@ public class DefaultRelatedItemsClient implements RelatedItemsClient {
                                      CollectorRepository collectorRepository,
                                      AutoDiscoveryRepository autoDiscoveryRepository) {
         this.relatedItemSettings = relatedItemSettings;
-        this.restOperations = restOperationsSupplier.get();
+        this.restClient = restClient;
         this.relatedCollectorItemRepository = relatedCollectorItemRepository;
         this.dashboardRepository = dashboardRepository;
         this.componentRepository = componentRepository;
@@ -212,10 +213,9 @@ public class DefaultRelatedItemsClient implements RelatedItemsClient {
     private ResponseEntity<String> makeRestCall(String payload, String token) {
         ResponseEntity<String> response = null;
         try {
-            response = restOperations.exchange(getSubscriberUrl(), HttpMethod.POST, new HttpEntity<>(payload, createHeaders(token, relatedItemSettings.getAccept())), String.class);
+            response = restClient.makeRestCallPost(getSubscriberUrl(), createHeaders(token, relatedItemSettings.getAccept()), payload);
         } catch (RestClientException re) {
-            LOGGER.error("Error with REST url: " + getSubscriberUrl());
-            LOGGER.error(re.getMessage());
+            LOGGER.error("Error with REST url: " + getSubscriberUrl(), re);
         }
         return response;
     }


### PR DESCRIPTION
Refactor: use common RestClient to make rest calls, so that error handling and log lines can be standardized