### PR TITLE
Auto Discovery Collector fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <repository.name>hygieia-relateditems-collector</repository.name>
         <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
         <bc.version>3.0.1</bc.version>
-        <com.capitalone.dashboard.core.version>3.1.14</com.capitalone.dashboard.core.version>
+        <com.capitalone.dashboard.core.version>3.1.15</com.capitalone.dashboard.core.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>3.8.1</commons.lang.version>
         <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>

--- a/src/main/java/com/capitalone/dashboard/client/DefaultRelatedItemsClient.java
+++ b/src/main/java/com/capitalone/dashboard/client/DefaultRelatedItemsClient.java
@@ -305,21 +305,19 @@ public class DefaultRelatedItemsClient implements RelatedItemsClient {
 
     private AutoDiscoverCollectorItem toAutoDiscoverCollectorItem(CollectorItem collectorItem, FeatureFlag featureFlag) {
         CollectorType collectorType = (Objects.isNull(collectorItem.getCollector())) ? findCollectorType(collectorItem.getCollectorId()) : collectorItem.getCollector().getCollectorType();
-        if(!HygieiaUtils.allowAutoDiscover(featureFlag, collectorType)) return null;
+        if (!HygieiaUtils.allowAutoDiscover(featureFlag, collectorType)) return null;
 
         AutoDiscoverCollectorItem autoDiscoverCollectorItem = new AutoDiscoverCollectorItem();
-        if (Objects.nonNull(collectorItem)) {
-            autoDiscoverCollectorItem.setId(collectorItem.getId());
-            autoDiscoverCollectorItem.setAutoDiscoverStatus(AutoDiscoveryStatusType.NEW);
-            autoDiscoverCollectorItem.setCollector(collectorItem.getCollector());
-            autoDiscoverCollectorItem.setOptions(collectorItem.getOptions());
-            autoDiscoverCollectorItem.setCollectorId(collectorItem.getCollectorId());
-            autoDiscoverCollectorItem.setEnabled(collectorItem.isEnabled());
-            autoDiscoverCollectorItem.setPushed(collectorItem.isPushed());
-            autoDiscoverCollectorItem.setDescription(collectorItem.getDescription());
-            autoDiscoverCollectorItem.setLastUpdated(collectorItem.getLastUpdated());
-            autoDiscoverCollectorItem.setNiceName(collectorItem.getNiceName());
-        }
+        autoDiscoverCollectorItem.setId(collectorItem.getId());
+        autoDiscoverCollectorItem.setAutoDiscoverStatus(AutoDiscoveryStatusType.NEW);
+        autoDiscoverCollectorItem.setCollector(collectorItem.getCollector());
+        autoDiscoverCollectorItem.setOptions(collectorItem.getOptions());
+        autoDiscoverCollectorItem.setCollectorId(collectorItem.getCollectorId());
+        autoDiscoverCollectorItem.setEnabled(collectorItem.isEnabled());
+        autoDiscoverCollectorItem.setPushed(collectorItem.isPushed());
+        autoDiscoverCollectorItem.setDescription(collectorItem.getDescription());
+        autoDiscoverCollectorItem.setLastUpdated(collectorItem.getLastUpdated());
+        autoDiscoverCollectorItem.setNiceName(collectorItem.getNiceName());
         return autoDiscoverCollectorItem;
     }
 

--- a/src/main/java/com/capitalone/dashboard/client/RelatedItemsUtils.java
+++ b/src/main/java/com/capitalone/dashboard/client/RelatedItemsUtils.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class RelatedItemsUtils {
+public final class RelatedItemsUtils {
 
     public static AutoDiscoveredEntry getEntry(AutoDiscoverCollectorItem adci) {
         AutoDiscoveredEntry autoDiscoveredEntry = new AutoDiscoveredEntry();

--- a/src/main/java/com/capitalone/dashboard/client/RelatedItemsUtils.java
+++ b/src/main/java/com/capitalone/dashboard/client/RelatedItemsUtils.java
@@ -1,8 +1,11 @@
 package com.capitalone.dashboard.client;
 
+import com.capitalone.dashboard.model.AutoDiscovery;
 import com.capitalone.dashboard.model.AutoDiscoverCollectorItem;
 import com.capitalone.dashboard.model.AutoDiscoveredEntry;
 import com.capitalone.dashboard.model.CollectorType;
+import com.capitalone.dashboard.model.FeatureFlag;
+import com.capitalone.dashboard.util.HygieiaUtils;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.util.ArrayList;
@@ -12,10 +15,6 @@ import java.util.List;
 public class RelatedItemsUtils {
 
     public static AutoDiscoveredEntry getEntry(AutoDiscoverCollectorItem adci) {
-        return toEntry(adci);
-    }
-
-    public static AutoDiscoveredEntry toEntry(AutoDiscoverCollectorItem adci) {
         AutoDiscoveredEntry autoDiscoveredEntry = new AutoDiscoveredEntry();
         autoDiscoveredEntry.setDescription(adci.getDescription());
         autoDiscoveredEntry.setNiceName(adci.getNiceName());
@@ -24,9 +23,8 @@ public class RelatedItemsUtils {
         return autoDiscoveredEntry;
     }
 
-
-    public static void setBuildEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.Build)) {
+    public static void setBuildEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.Build.equals(collectorType)) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getBuildEntries())) {
                 List<AutoDiscoveredEntry> builds = autoDiscovery.getBuildEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();
@@ -40,8 +38,8 @@ public class RelatedItemsUtils {
 
     }
 
-    public static void setCodeRepoEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.SCM)) {
+    public static void setCodeRepoEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.SCM.equals(collectorType)) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getCodeRepoEntries())) {
                 List<AutoDiscoveredEntry> repos = autoDiscovery.getCodeRepoEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();
@@ -54,8 +52,8 @@ public class RelatedItemsUtils {
         }
     }
 
-    public static void setStaticCodeEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.CodeQuality)) {
+    public static void setStaticCodeEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.CodeQuality.equals(collectorType)) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getStaticCodeEntries())) {
                 List<AutoDiscoveredEntry> staticCodeEntries = autoDiscovery.getStaticCodeEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();
@@ -68,8 +66,8 @@ public class RelatedItemsUtils {
         }
     }
 
-    public static void setLibraryPolicyEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.LibraryPolicy)) {
+    public static void setLibraryPolicyEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.LibraryPolicy.equals(collectorType)) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getLibraryScanEntries())) {
                 List<AutoDiscoveredEntry> libraryScanEntries = autoDiscovery.getLibraryScanEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();
@@ -83,8 +81,8 @@ public class RelatedItemsUtils {
         }
     }
 
-    public static void setStaticSecurityEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.StaticSecurityScan)) {
+    public static void setStaticSecurityEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.StaticSecurityScan.equals(collectorType) ) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getStaticCodeEntries())) {
                 List<AutoDiscoveredEntry> securityScanEntries = autoDiscovery.getSecurityScanEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();
@@ -97,8 +95,8 @@ public class RelatedItemsUtils {
         }
     }
 
-    public static void setArtifactEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.Artifact)) {
+    public static void setArtifactEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.Artifact.equals(collectorType)) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getArtifactEntries())) {
                 List<AutoDiscoveredEntry> artifactEntries = autoDiscovery.getArtifactEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();
@@ -111,8 +109,8 @@ public class RelatedItemsUtils {
         }
     }
 
-    public static void setDeployEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.Deployment)) {
+    public static void setDeployEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.Deployment.equals(collectorType)) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getDeploymentEntries())) {
                 List<AutoDiscoveredEntry> deploymentEntries = autoDiscovery.getDeploymentEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();
@@ -125,8 +123,8 @@ public class RelatedItemsUtils {
         }
     }
 
-    public static void setFunctionalTestEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.Test)) {
+    public static void setFunctionalTestEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.Test.equals(collectorType)) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getFunctionalTestEntries())) {
                 List<AutoDiscoveredEntry> functionalTestEntries = autoDiscovery.getFunctionalTestEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();
@@ -139,8 +137,8 @@ public class RelatedItemsUtils {
         }
     }
 
-    public static void setFeatureEntries(com.capitalone.dashboard.model.AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType) {
-        if (collectorType.equals(CollectorType.AgileTool)) {
+    public static void setFeatureEntries(AutoDiscovery autoDiscovery, AutoDiscoverCollectorItem adci, CollectorType collectorType, FeatureFlag featureFlag) {
+        if (HygieiaUtils.allowAutoDiscover(featureFlag,collectorType) && CollectorType.AgileTool.equals(collectorType)) {
             if (CollectionUtils.isNotEmpty(autoDiscovery.getFeatureEntries())) {
                 List<AutoDiscoveredEntry> featureEntries = autoDiscovery.getFeatureEntries();
                 List<AutoDiscoveredEntry> ls = new ArrayList<>();


### PR DESCRIPTION
- Implement Feature flags to be processed by collector.
- Remove duplicates from the entries in auto_discovery_status collection.
- For entries disabled by feature flag the entries will be emptied in auto_discovery_status collection.